### PR TITLE
Fix issues with upserting and defaults

### DIFF
--- a/bearfield/document.py
+++ b/bearfield/document.py
@@ -116,9 +116,9 @@ class Document(object):
                         default = field.encode(cls._meta.cls, name, default())
                     defaults[name] = default
             set_on_insert = update.get('$setOnInsert', {})
-            set_on_insert.update(defaults)
+            defaults.update(set_on_insert)
             update.update({
-                '$setOnInsert': set_on_insert
+                '$setOnInsert': defaults
             })
         raw = collection.find_one_and_update(criteria, update, projection=get_projection(fields),
                                              new=new, sort=sort, **options)

--- a/tests/document_test.py
+++ b/tests/document_test.py
@@ -261,6 +261,18 @@ class TestDocument(common.TestCase):
         self.assertIsNotNone(doc)
         self.assertEqual(doc.index, 12)
 
+    def test_find_and_modify_upsert_do_not_clobber_set_on_insert(self):
+        doc = Defaults.find_and_modify(
+            {'name': 'a name'},
+            {
+                '$setOnInsert': {
+                    'index': 15,
+                }
+            },
+            new=True, upsert=True)
+        self.assertIsNotNone(doc)
+        self.assertEqual(doc.index, 15)
+
     def test_subdocument(self):
         """Document.save/find with subdocument"""
         self.assertFalse(

--- a/tests/document_test.py
+++ b/tests/document_test.py
@@ -273,6 +273,18 @@ class TestDocument(common.TestCase):
         self.assertIsNotNone(doc)
         self.assertEqual(doc.index, 15)
 
+    def test_find_and_modify_upsert_defaults_do_not_conflict_with_update(self):
+        doc = Defaults.find_and_modify(
+            {'name': 'a name'},
+            {
+                '$set': {
+                    'index': 20,
+                }
+            },
+            new=True, upsert=True)
+        self.assertIsNotNone(doc)
+        self.assertEqual(doc.index, 20)
+
     def test_subdocument(self):
         """Document.save/find with subdocument"""
         self.assertFalse(

--- a/tests/document_test.py
+++ b/tests/document_test.py
@@ -325,6 +325,15 @@ class TestDocument(common.TestCase):
         self.assertEqual(raw.get('index'), 12, "encoded value is incorrect")
         self.assertIsNone(raw.get('name'), "encoded value is incorrect")
 
+    def test_defaults_save(self):
+        doc = Defaults().save()
+        self.assertEqual(doc.index, 12, "attribute value is incorrect")
+        self.assertIsNone(doc.name, "attribute value is incorrect")
+        self.assertEqual(doc.called, ['0', '1'])
+        raw = doc._encode()
+        self.assertEqual(raw.get('index'), 12, "encoded value is incorrect")
+        self.assertIsNone(raw.get('name'), "encoded value is incorrect")
+
     def test_modifier(self):
         """Field modifiers""" 
         now = datetime.now()


### PR DESCRIPTION
- Values set in the `$setOnInsert` dict are not clobbered
- If a field is specified in an upsert in another update operator, the default will not be added into the pymongo call in the `$setOnInsert` dict.