### PR TITLE
don't convert None to 'None' when encoding builtin types

### DIFF
--- a/bearfield/types.py
+++ b/bearfield/types.py
@@ -136,6 +136,8 @@ class BuiltinType(FieldType):
 
     def encode(self, cls, name, value):
         """Return the encoded value."""
+        if value is None:
+            return value
         try:
             return self.builtin(value)
         except (TypeError, ValueError):


### PR DESCRIPTION
@BlueDragonX @kaiumezawa This is where we're getting all those "None" strings from. Ryan, I didn't really see a need to do this across the board for all types, since it should theoretically only be an issue for fields with type `str`, which use `unicode()` to encode their values in update queries, but let me know if you think that's necessary. Anything that uses `Field(str)` in a document subclass will do this on those fields without providing a `raw` kwarg to `find_and_modify()`